### PR TITLE
Add if-statement in parser to skip over blank lines

### DIFF
--- a/mtools/gromacs/gromacs.py
+++ b/mtools/gromacs/gromacs.py
@@ -169,6 +169,8 @@ def parse_nonbond_params(top_file, gmxtop):
     with open(top_file, 'r') as top:
         for line in top:
             line = line.strip()
+            if not line:
+                continue
             if line[0] == ';':
                 continue
             if line[0] == '[':


### PR DESCRIPTION
The dry MXene example was failing because `nonbond_params.txt` contains blank lines.  The addition of an if-statement in `parse_nonbond_params` to skip over this line seems to have fixed this issue.